### PR TITLE
Updated Podfile to fix WatchdogInspector (from ) error for cocoapod v…

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,1 +1,5 @@
-pod "WatchdogInspector", :path => "../WatchdogInspector.podspec"
+platform :ios, '8.0'
+
+target "WatchdogExample" do
+    pod "WatchdogInspector", :path => "../WatchdogInspector.podspec"
+end


### PR DESCRIPTION
…ersion 1.0.0.beta.4

When i tried to run example project i got `[!] The dependency`WatchdogInspector (from `../WatchdogInspector.podspec`)`is not used in any concrete target.` and i am using cocoapods with version 1.0.0.beta.4` adding these lines into Podfile fixed the issue.
